### PR TITLE
DEVOPS-1651:  Merge in the gem->deb version fix 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners,
+# the last matching pattern has the most precendence.
+* @roivant/devops
+CODEOWNERS @roivant/devops
+/devops/ @roivant/devops
+/Berksfile* @roivant/devops
+/Gemfile* @roivant/devops
+/Jenkinsfile* @roivant/devops
+/Pipfile* @roivant/devops
+/Rakefile* @roivant/devops
+/repository_metadata.yaml @roivant/devops
+/Vagrantfile @roivant/devops

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description of change
+
+## Reason for change
+
+## Checklist
+
+### Guidelines
+This PR has:
+* [ ] less than 500 lines of diff
+* [ ] is less than 3 days old
+* [ ] is for 1 and only 1 purpose
+
+### Types of changes
+* [ ] Bug fix (non-breaking change which fixes an issue)
+* [ ] New feature (non-breaking change which adds functionality)
+* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+### Administrative
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
+* [ ] If required, I have updated the documentation accordingly.
+
+### Versioning
+* [ ] Have you updated the lib/fpm/version.rb?
+* [ ] Have you updated the lib/fpm/repository_metadata.yaml with the matching version?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Release Notes and Change Log
 ============================
 
+1.11.1 (January 30, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Roivant fork begins here.
+* deb: fix version constraints when a gem uses just a major. (ex: `>=3`) (`#755`)
+
 1.11.0 (January 30, 2019)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -102,7 +108,7 @@ Yanked offline. I forgot some dependency changes. Hi.
 * FreeBSD: --architecture (-a) flag now sets FreeBSD package ABI (`#1196`_; Matt Sharpe)
 * perl/cpan: Fix bug and now local modules can be packaged (`#1202`_, `#1203`_; liger1978)
 * perl/cpan: Add support for `http_proxy` environment variable and improve how fpm queries CPAN for package information. (`#1206`_, `#1208`_; liger1978)
-* Fix crash for some users (`#1231`_, `#1148`_; Jose Diaz-Gonzalez) 
+* Fix crash for some users (`#1231`_, `#1148`_; Jose Diaz-Gonzalez)
 * Documentation now published on fpm.readthedocs.io. This is a work-in progress. Contributions welcome! <3 (`#1237`_, Jordan Sissel)
 * deb: Can now read bz2-compressed debian packages. (`#1213`_; shalq)
 * pleaserun: New flag --pleaserun-chdir for setting the working directory of a service. (`#1235`_; Claus F. Strasburger)
@@ -131,7 +137,7 @@ Yanked offline. I forgot some dependency changes. Hi.
 * deb: don't append `.conf` to an upstart file if the file name already ends in `.conf`. (`#1115`_, josegonzalez)
 * freebsd: fix bug where --package flag was ignored. (`#1093`_, Paweł Tomulik)
 * Improvements to the fpm rake tasks (`#1101`_, Evan Gilman)
-  
+
 1.5.0 (April 12, 2016)
 ^^^^^^^^^^^^^^^^^^^^^^
 * Arch package support is now available via -s pacman and -t pacman.  (`#916`_; wonderful community effort making this happen!)
@@ -173,7 +179,7 @@ Yanked offline. I forgot some dependency changes. Hi.
 * If PATH isn't set, and we need it, tell the user (`#886`_, Ranjib Dey)
 * cpan: --[no-]cpan-test now works correctly (`#853`_, Matt Schreiber)
 * deb-to-rpm: some improved support for config file knowledge passing from deb to rpm packages (Daniel Haskin)
-    
+
 1.3.3 (December 11, 2014)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 * The fpm project now uses Contributor Covenant. You can read more about this on the website: http://contributor-covenant.org/
@@ -188,7 +194,7 @@ Yanked offline. I forgot some dependency changes. Hi.
 ^^^^^^^^^^^^^^^^^^^^^^^^
 * deb: fix md5sums generation such that `dpkg -V` now works (`#799`_, Matteo Panella)
 * rpm: Use maximum compression when choosing xz (`#797`_, Ashish Kulkarni)
-  
+
 1.3.0 (October 25, 2014)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 * Fixed a bunch of Ruby 1.8.7-related bugs. (Jordan Sissel)
@@ -308,7 +314,7 @@ Yanked offline. I forgot some dependency changes. Hi.
 0.4.39 (June 27, 2013)
 ^^^^^^^^^^^^^^^^^^^^^^
 * cpan: support more complex dependency specifications (reported by Mabi Knittel)
-  
+
 0.4.38 (June 24, 2013)
 ^^^^^^^^^^^^^^^^^^^^^^
 * cpan: fpm's cpan code now works under ruby 1.8.7
@@ -331,7 +337,7 @@ Yanked offline. I forgot some dependency changes. Hi.
 * cpan: --no-cpan-test now skips tests for build/configure dependencies
 * rpm: Add --rpm-defattrfile and --rpm-defattrdir flags (`#428`_, patch by phrawzty)
 
-0.4.35 -- was not announced 
+0.4.35 -- was not announced
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 0.4.34 (May 7, 2013)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release Notes and Change Log
 ============================
 
-1.11.1 (January 30, 2019)
+3.0.0 (April 24, 2019)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Roivant fork begins here.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,16 @@
 fpm
 ===
 
+ROIVANT specific notes:
+-----------------------
+* Update the CHANGELOG.md with what changed in this version.
+* Update the version in `lib/fpm/version.rb`
+    * Make sure to follow semver rules.
+* `gem build fpm`
+* `gem push fpm-<version>.gem --host https://artifactory.vant.com/artifactory/api/gems/roivant-gems`
+
+===
+
 |Build| |Chat| |Gem|
 
 The goal of fpm is to make it easy and quick to build packages such as rpms,

--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -20,6 +20,12 @@ Gem::Specification.new do |spec|
     "management without wasting pointless hours debugging bad rpm specs!"
   spec.license = "MIT-like"
 
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = 'https://artifactory.vant.com/artifactory/api/gems/roivant-gems'
+  else
+    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+  end
+
   spec.required_ruby_version = '>= 1.9.3'
 
   # For parsing JSON (required for some Python support, etc)

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -713,16 +713,13 @@ class FPM::Package::Deb < FPM::Package
     # Convert gem ~> X.Y.Z to '>= X.Y.Z' and << X.Y+1.0
     if dep =~ /\(~>/
       name, version = dep.gsub(/[()~>]/, "").split(/ +/)[0..1]
-      if version.match(/\./)
-        nextversion = version.split(".").collect { |v| v.to_i }
-        l = nextversion.length
-        nextversion[l-2] += 1
-        nextversion[l-1] = 0
-        nextversion = nextversion.join(".")
-        return ["#{name} (>= #{version})", "#{name} (<< #{nextversion})"]
-      else
-        return "#{name} (>= #{version})"
-      end
+      version = "#{version}.0" unless version.match(/\./)
+      nextversion = version.split(".").collect { |v| v.to_i }
+      l = nextversion.length
+      nextversion[l-2] += 1
+      nextversion[l-1] = 0
+      nextversion = nextversion.join(".")
+      return ["#{name} (>= #{version})", "#{name} (<< #{nextversion})"]
     elsif (m = dep.match(/(\S+)\s+\(!= (.+)\)/))
       # Move '!=' dependency specifications into 'Breaks'
       self.attributes[:deb_breaks] ||= []

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -713,12 +713,16 @@ class FPM::Package::Deb < FPM::Package
     # Convert gem ~> X.Y.Z to '>= X.Y.Z' and << X.Y+1.0
     if dep =~ /\(~>/
       name, version = dep.gsub(/[()~>]/, "").split(/ +/)[0..1]
-      nextversion = version.split(".").collect { |v| v.to_i }
-      l = nextversion.length
-      nextversion[l-2] += 1
-      nextversion[l-1] = 0
-      nextversion = nextversion.join(".")
-      return ["#{name} (>= #{version})", "#{name} (<< #{nextversion})"]
+      if version.match(/\./)
+        nextversion = version.split(".").collect { |v| v.to_i }
+        l = nextversion.length
+        nextversion[l-2] += 1
+        nextversion[l-1] = 0
+        nextversion = nextversion.join(".")
+        return ["#{name} (>= #{version})", "#{name} (<< #{nextversion})"]
+      else
+        return "#{name} (>= #{version})"
+      end
     elsif (m = dep.match(/(\S+)\s+\(!= (.+)\)/))
       # Move '!=' dependency specifications into 'Breaks'
       self.attributes[:deb_breaks] ||= []

--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "1.11.0"
+  VERSION = "1.11.1"
 end

--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "1.11.1"
+  VERSION = "3.0.0"
 end

--- a/repository_metadata.yaml
+++ b/repository_metadata.yaml
@@ -1,0 +1,4 @@
+---
+owner: "@roivant/devops"
+version: 1.11.1
+billing_entity: devops

--- a/repository_metadata.yaml
+++ b/repository_metadata.yaml
@@ -1,4 +1,4 @@
 ---
 owner: "@roivant/devops"
-version: 1.11.1
+version: 3.0.0
 billing_entity: devops

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -138,7 +138,6 @@ describe FPM::Package::Deb do
       original.architecture = "all"
       original.dependencies << "something > 10"
       original.dependencies << "hello >= 20"
-      original.dependencies << "semver ~> 3"
       original.provides << "#{original.name} = #{original.version}"
 
       # Test to cover PR#591 (fix provides names)

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -138,6 +138,7 @@ describe FPM::Package::Deb do
       original.architecture = "all"
       original.dependencies << "something > 10"
       original.dependencies << "hello >= 20"
+      original.dependencies << "semver ~> 3"
       original.provides << "#{original.name} = #{original.version}"
 
       # Test to cover PR#591 (fix provides names)
@@ -261,7 +262,7 @@ describe FPM::Package::Deb do
 
       it "should have the correct dependency list" do
         # 'something > 10' should convert to 'something (>> 10)', etc.
-        insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20)"
+        insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20), semver (>= 3)"
       end
 
       it "should have the correct replaces list" do

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -262,7 +262,7 @@ describe FPM::Package::Deb do
 
       it "should have the correct dependency list" do
         # 'something > 10' should convert to 'something (>> 10)', etc.
-        insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20), semver (>= 3)"
+        insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20), semver (>= 3.0), semver (<< 4.0)"
       end
 
       it "should have the correct replaces list" do


### PR DESCRIPTION
Merge the fix where gems create debian packages with unsatisfy-able constraints if the version is just the major.