### PR TITLE
DEVOPS-2088: copy built native extensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release Notes and Change Log
 3.0.1 (April 25, 2019)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* gem: copy built native extensions (.so files, etc) to /usr/lib64; configurable by `--extensiondir` (`DEVOPS-2088`)
+* gem: copy built native extensions (.so files, etc) to `/usr/lib64/gems/ruby/`; configurable by `--extensiondir` (`DEVOPS-2088`)
 
 3.0.0 (April 24, 2019)
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Release Notes and Change Log
 ============================
 
+3.0.1 (April 25, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* gem: copy built native extensions (.so files, etc) to /usr/lib64; configurable by `--extensiondir` (`DEVOPS-2088`)
+
 3.0.0 (April 24, 2019)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/repository_metadata.yaml
+++ b/repository_metadata.yaml
@@ -1,4 +1,4 @@
 ---
 owner: "@roivant/devops"
-version: 3.0.0
+version: 3.0.1
 billing_entity: devops


### PR DESCRIPTION
## Description of change
gem: copy built native extensions (.so files, etc) to /usr/lib64; configurable by `--extensiondir` 

## Reason for change
the libs weren't found, and the user was seeing messages like: 
```
Ignoring ffi-1.10.0 because its extensions are not built. Try: gem pristine ffi --version 1.10.0
```

## Checklist

### Guidelines
This PR has:
* [x] less than 500 lines of diff
* [x] is less than 3 days old
* [x] is for 1 and only 1 purpose

### Types of changes
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Administrative
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] If required, I have updated the documentation accordingly.

### Versioning
* [x] Have you updated the lib/fpm/version.rb?
* [x] Have you updated the lib/fpm/repository_metadata.yaml with the matching version?